### PR TITLE
Support for reading offset from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out/
 *.class
+lib/
+test/

--- a/FakeTimeFileTest.java
+++ b/FakeTimeFileTest.java
@@ -8,7 +8,7 @@ public class FakeTimeFileTest {
     final Path filePath = Files.createTempFile(null, null);
     System.out.println("Using temporary file " + filePath.toString());
     
-    System.setProperty("faketime.file.path", filePath.toAbsolutePath().toString());
+    System.setProperty("faketime.offset.file", filePath.toAbsolutePath().toString());
 
     for(int i = 0; i < 10; i++) {
       Files.write(filePath, String.valueOf(i * -86400).getBytes("UTF-8"));

--- a/FakeTimeFileTest.java
+++ b/FakeTimeFileTest.java
@@ -1,0 +1,21 @@
+import java.util.Calendar;
+import java.lang.String;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class FakeTimeFileTest {
+  public static void main(String args[]) throws Throwable{
+    final Path filePath = Files.createTempFile(null, null);
+    System.out.println("Using temporary file " + filePath.toString());
+    
+    System.setProperty("faketime.file.path", filePath.toAbsolutePath().toString());
+
+    for(int i = 0; i < 10; i++) {
+      Files.write(filePath, String.valueOf(i * -86400).getBytes("UTF-8"));
+
+      System.out.println("Time: " + System.currentTimeMillis());
+      Calendar calendar = Calendar.getInstance();
+      System.out.println("Date: " + calendar.getTime());
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ OR
 
 ##### Option 2: Control offset with an offset file
 
-You can set the property **faketime.file.path** to point to a file containing the offset in *seconds* (ASCII-encoded). This way you can alter the time using methods external to the Java process, i.e. through a mounted Kubernetes ConfigMap.
+You can set the property **faketime.offset.file** to point to a file containing the offset in *seconds* (ASCII-encoded). This way you can alter the time using methods external to the Java process, i.e. through a mounted Kubernetes ConfigMap.
 
 ```
 java -agentpath:/path/to/the/library/you/got/above \
-  -Dfaketime.file.path=/path/to/a/text/file/containing/a/number
+  -Dfaketime.offset.file=/path/to/a/text/file/containing/a/number
   -XX:+UnlockDiagnosticVMOptions \
   -XX:DisableIntrinsic=_currentTimeMillis \
   -XX:CompileCommand=exclude,java/lang/System.currentTimeMillis \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ gcc -fPIC -shared -I $JAVA_HOME/include -I $JAVA_HOME/include/linux -m32 -Wall s
 
 ### Step 2: Use it:
 
+##### Option 1: Control offset with a Java system property
+
 Run your Java program (say, org.test.Main) with these agent-specific extra arguments (see [issue #3](https://github.com/arvindsv/faketime/issues/3)), like this:
 
 ```
@@ -63,5 +65,21 @@ In your Java code, you can set the property **faketime.offset.seconds** to the n
 ```
 System.setProperty("faketime.offset.seconds", "86400");
 ```
+
+OR
+
+##### Option 2: Control offset with an offset file
+
+You can set the property **faketime.file.path** to point to a file containing the offset in *seconds* (ASCII-encoded). This way you can alter the time using methods external to the Java process, i.e. through a mounted Kubernetes ConfigMap.
+
+```
+java -agentpath:/path/to/the/library/you/got/above \
+  -Dfaketime.file.path=/path/to/a/text/file/containing/a/number
+  -XX:+UnlockDiagnosticVMOptions \
+  -XX:DisableIntrinsic=_currentTimeMillis \
+  -XX:CompileCommand=exclude,java/lang/System.currentTimeMillis \
+  org.test.Main
+```
+
         
 That's it! Take a look at [FakeTimeTest.java](https://github.com/arvindsv/faketime/blob/master/FakeTimeTest.java) if you need to see some Java code which uses it.

--- a/src/FakeTimeAgent.c
+++ b/src/FakeTimeAgent.c
@@ -56,7 +56,7 @@ JNIEXPORT jlong JNICALL newCurrentTimeInMillis(JNIEnv* env, jclass jc) {
 
   jstring offsetPropertyName = (*env)->NewStringUTF(env, "faketime.offset.seconds");
   jstring offsetPropertyDefault = (*env)->NewStringUTF(env, "0");
-  jstring filePathPropertyName = (*env)->NewStringUTF(env, "faketime.file.path");
+  jstring filePathPropertyName = (*env)->NewStringUTF(env, "faketime.offset.file");
   //jstring fileCacheDurationPropertyName = (*env)->NewStringUTF(env, "faketime.file.cache_duration");
   //jstring fileCacheDurationPropertyDefault = (*env)->NewStringUTF(env, "10");
 

--- a/test_linux.sh
+++ b/test_linux.sh
@@ -5,4 +5,7 @@ gcc -shared -I $JAVA_HOME/include -I $JAVA_HOME/include/linux -m32 -Wall src/Fak
 mkdir -p lib/linux && mv libfaketime.so lib/linux/ 
 
 javac FakeTimeTest.java 
+javac FakeTimeFileTest.java
+
 java -agentpath:./lib/linux/libfaketime.so FakeTimeTest
+java -agentpath:./libfaketime.so FakeTimeFileTest

--- a/test_linux_64.sh
+++ b/test_linux_64.sh
@@ -2,7 +2,10 @@
 set -eu
 
 gcc -fPIC -shared -I $JAVA_HOME/include -I $JAVA_HOME/include/linux -m64 -Wall src/FakeTimeAgent.c -o libfaketime.so 
-mkdir -p lib/linux && mv libfaketime.so lib/linux/ 
+mkdir -p lib/linux && mv libfaketime.so lib/linux/
 
-javac FakeTimeTest.java 
+javac FakeTimeTest.java
+javac FakeTimeFileTest.java
+
 java -agentpath:./lib/linux/libfaketime.so FakeTimeTest
+java -agentpath:./lib/linux/libfaketime.so FakeTimeFileTest

--- a/test_mac.sh
+++ b/test_mac.sh
@@ -5,4 +5,7 @@ gcc -shared -I $JAVA_HOME/include -Wall src/FakeTimeAgent.c -o libfaketime.jnili
 mkdir -p lib/mac/ && mv libfaketime.jnilib lib/mac/
 
 javac FakeTimeTest.java 
+javac FakeTimeFileTest.java
+
 java -agentpath:./lib/mac/libfaketime.jnilib FakeTimeTest
+java -agentpath:./lib/mac/libfaketime.jnilib FakeTimeFileTest


### PR DESCRIPTION
To implement a use case of a Java application running in Kubernetes, I needed to be able to dynamically set the time offset from outside the Java process.
Every time `System.currentTimeMillis()` is called, the offset is now read from the file specified in the Java property `faketime.offset.file` instead of directly from the property `faketime.offset.seconds`. If the property is not set, the offset in `faketime.offset.seconds` is used as before.

This enables one to dynamically set the offset in a Kubernetes ConfigMap object, which is mounted in the Java application container as a file.